### PR TITLE
Don't store null terminator in string buffer

### DIFF
--- a/zend_tombs_strings.c
+++ b/zend_tombs_strings.c
@@ -103,7 +103,6 @@ _zend_tombs_strings_check:
            ZSTR_VAL(string),
            ZSTR_LEN(string));
 
-    copy->value[ZSTR_LEN(string)] = 0;
     copy->hash = ZSTR_HASH(string);
 
     __atomic_store_n(&copy->length, ZSTR_LEN(string), __ATOMIC_SEQ_CST);


### PR DESCRIPTION
We were not accounting for the null terminator in the string allocation, meaning that every string copy overflowed its buffer by one byte.

Usually the null terminator ended up getting overwritten by the first character of the next string copied into the buffer, but occasionally, due to concurrency, the null terminator from the first string could overwrite the first character of the second.

Since the null terminator is not actually necessary, this commit removes it from the string buffer. Now the allocation size is correct.

Fixes #16 using the first solution suggested in that issue. Read that issue for further details. The alternative would be to increase each string allocation size by 1.