### PR TITLE
Escape backslashes when outputting JSON

### DIFF
--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Check if namespaced tomb is detected and name JSON-escaped (function)
+--INI--
+tombs.socket=tcp://127.0.0.1:8010
+--FILE--
+<?php
+namespace A\B\C {
+
+include "zend_tombs.inc";
+
+function test() {}
+
+zend_tombs_display("127.0.0.1", 8010);
+}
+?>
+--EXPECTF--
+{"location": {"file": "%s007.php", "start": 6, "end": 6}, "function": "A\\B\\C\\test"}
+

--- a/zend_tombs_graveyard.c
+++ b/zend_tombs_graveyard.c
@@ -134,9 +134,30 @@ void zend_tombs_graveyard_vacate(zend_tombs_graveyard_t *graveyard, zend_long sl
     __zend_tomb_destroy(graveyard, tomb);
 }
 
+static void zend_tombs_string_escape(zend_tombs_string_t *escaped, const zend_tombs_string_t *raw, zend_long limit) {
+    char *dst = escaped->value;
+    char *dst_end = dst + limit;
+    char *src = raw->value;
+    char *src_end = src + raw->length;
+    while (src < src_end && dst < dst_end) {
+        if (*src == '\\') {
+            *dst++ = '\\';
+            if (dst >= dst_end) {
+                break;
+            }
+        }
+        *dst++ = *src++;
+    }
+    escaped->length = dst - escaped->value;
+}
+
 void zend_tombs_graveyard_dump_json(zend_tombs_graveyard_t *graveyard, int fd) {
     zend_tomb_t *tomb = graveyard->tombs,
                 *end  = tomb + graveyard->slots;
+
+    zend_tombs_string_t escaped;
+    char escaped_buffer[256];
+    escaped.value = escaped_buffer;
 
     while (tomb < end) {
         if (__atomic_load_n(&tomb->state.populated, __ATOMIC_SEQ_CST)) {
@@ -145,7 +166,8 @@ void zend_tombs_graveyard_dump_json(zend_tombs_graveyard_t *graveyard, int fd) {
             zend_tombs_graveyard_write_literal(fd, "\"location\": {");
             if (tomb->location.file) {
                 zend_tombs_graveyard_write_literal(fd, "\"file\": \"");
-                zend_tombs_graveyard_write_string(fd, tomb->location.file);
+                zend_tombs_string_escape(&escaped, tomb->location.file, sizeof(escaped_buffer));
+                zend_tombs_graveyard_write_string(fd, &escaped);
                 zend_tombs_graveyard_write_literal(fd, "\", ");
             }
 
@@ -161,12 +183,14 @@ void zend_tombs_graveyard_dump_json(zend_tombs_graveyard_t *graveyard, int fd) {
 
             if (tomb->scope) {
                 zend_tombs_graveyard_write_literal(fd, "\"scope\": \"");
-                zend_tombs_graveyard_write_string(fd, tomb->scope);
+                zend_tombs_string_escape(&escaped, tomb->scope, sizeof(escaped_buffer));
+                zend_tombs_graveyard_write_string(fd, &escaped);
                 zend_tombs_graveyard_write_literal(fd, "\", ");
             }
 
             zend_tombs_graveyard_write_literal(fd, "\"function\": \"");
-            zend_tombs_graveyard_write_string(fd, tomb->function);
+            zend_tombs_string_escape(&escaped, tomb->function, sizeof(escaped_buffer));
+            zend_tombs_graveyard_write_string(fd, &escaped);
             zend_tombs_graveyard_write_literal(fd, "\"");
 
             zend_tombs_graveyard_write_literal(fd, "}\n");


### PR DESCRIPTION
This adds a new function, `zend_tombs_string_escape`, which copies a string, doubling backslashes to escape them. So the string `"a\b\c"` becomes `"a\\b\\c"`. This is important when dumping JSON, since currently namespaces cause tombs to emit invalid JSON. I imagine there are also problems with Windows file paths, but I don't use Windows so can't say for sure.

I've arbitrarily limited the strings to 256 bytes. This seems like it should be plenty but I'm open to feedback. Strings beyond that length are truncated.

Fixes #12 for the most part. There are still cases where invalid JSON can be emitted, but they should be much less common.